### PR TITLE
fix(AR-154): fix the validation message of the unique participant field

### DIFF
--- a/src/service/ParticipiantService.ts
+++ b/src/service/ParticipiantService.ts
@@ -66,13 +66,13 @@ async function add(formSlug: string, type: ACCESS_TYPE, data: Participiant): Pro
 
 async function _parseCreateErrors(e: any, formSlug: string): Promise<void> {
     if (e?.name === 'MongoError' && e?.code === MONGO_UNIQUE_ERROR && e?.keyPattern) {
-        const [key, value] = Object.entries(e?.keyPattern)[0]
+        const [key, value] = Object.entries(e?.keyValue)[0]
         const schema = await _getSchema(formSlug)
         if (!schema) throw e
         const field = schema.structure[key]
         if (!field) throw e
         throw Exception.fromMessage(
-            `Pole: ${field.label} musi mieć unikalną wartość. Mamy już uczestnika w systemie którego ${field.label} jest ${value}`,
+            `Pole "${field.label}" musi mieć unikalną wartość. Mamy już uczestnika, który posiada wprowadzoną wartość "${value}" do wydarzenia.`,
             422
         )
     } else throw e


### PR DESCRIPTION
Poprawa komunikatu jaki jest zwracany kiedy próbujemy utworzyć nowego uczestnika z polem, które dla każdego uczestnika ma być unikalne. Do tego momentu pod wartością `value` w zmienionym kodzie zamiast duplikowanej wartości było po prostu "1". Teraz wyciągam faktycznie wartość, która będzie pomocna użytkownikowi, który będzie dodawał/edytował uczestnika. 